### PR TITLE
Set client max protocol to SMB3 by default (instead of SMB1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def pkgconfig_I (pkg):
     return dirs
     
 setup (name="pysmbc",
-       version="1.0.15.6",
+       version="1.0.15.7",
        description="Python bindings for libsmbclient",
        long_description=__doc__,
        author=["Tim Waugh <twaugh@redhat.com>",

--- a/smbc/context.c
+++ b/smbc/context.c
@@ -140,6 +140,9 @@ Context_init (Context *self, PyObject *args, PyObject *kwds)
       Py_XINCREF (auth);
       self->auth_fn = auth;
     }
+	
+  debugprintf ("-> Setting  client max protocol to SMB3()\n");
+  lp_set_cmdline("client max protocol", "SMB3");
 
   debugprintf ("-> Context_init ()\n");
 


### PR DESCRIPTION
By default, the **client max version** configuration of libsmbclient uses SMB1.

We set the max version to hardcoded **SMB3** (similar to `-m SMB3` flag in `smbclient`).

New server do not longer support SMB1 (more because of wannacry).